### PR TITLE
Allow users to define the aspect ratio of prov report images

### DIFF
--- a/data_management/prov.py
+++ b/data_management/prov.py
@@ -334,16 +334,21 @@ def generate_prov_document(data_product, request):
     return doc
 
 
-def serialize_prov_document(doc, format_, show_attributes=True):
+def serialize_prov_document(doc, format_, aspect_ratio, show_attributes=True):
     """
     Serialise a PROV document as either a JPEG or SVG image or an XML or PROV-N report.
 
     :param doc: A PROV-O document
     :param format_: The format to generate: jpg, svg, xml or provn
+    :param aspect_ratio: a float used to define the ratio for images
+    :param show_attributes: a boolean
+
     :return: The PROV report in the specified format
+
     """
     if format_ in ('jpg', 'svg'):
         dot = prov.dot.prov_to_dot(doc, show_element_attributes=show_attributes)
+        dot.set_ratio(aspect_ratio)
         with io.BytesIO() as buf:
             if format_ == 'jpg':
                 buf.write(dot.create_jpg())
@@ -351,18 +356,21 @@ def serialize_prov_document(doc, format_, show_attributes=True):
                 buf.write(dot.create_svg())
             buf.seek(0)
             return buf.read()
+
     elif format_ == 'xml':
         with io.StringIO() as buf:
             serializer = prov.serializers.get('xml')
             serializer(doc).serialize(buf)
             buf.seek(0)
             return buf.read()
+
     elif format_ == 'provn':
         with io.StringIO() as buf:
             serializer = prov.serializers.get('provn')
             serializer(doc).serialize(buf)
             buf.seek(0)
             return buf.read()
+
     else:
         with io.StringIO() as buf:
             serializer = prov.serializers.get('json')

--- a/data_management/rest/views.py
+++ b/data_management/rest/views.py
@@ -119,9 +119,18 @@ class ProvReportView(views.APIView):
         show_attributes = request.query_params.get('attributes', True)
         if show_attributes == "False":
             show_attributes = False
+
+        default_aspect_ratio = 0.71
+        aspect_ratio = request.query_params.get('aspect_ratio', default_aspect_ratio)
+        try:
+            aspect_ratio = float(aspect_ratio)
+        except ValueError:
+            aspect_ratio = default_aspect_ratio
+
         value = serialize_prov_document(
             doc,
             request.accepted_renderer.format,
+            aspect_ratio,
             show_attributes=bool(show_attributes)
         )
         return Response(value)


### PR DESCRIPTION
Add a new optional parameter `aspect_ratio` to the `ProvReportView`
This is used to set the aspect ratio of the svg and jpg images produced
for the prov report. The value of `aspect_ratio` should be a float. If
is not a float or not present then a value of 0.71 will be used. 0.71 is
the aspect ratio of landscape A4 paper