### PR TITLE
Add example data

### DIFF
--- a/data_management/management/commands/_example_data.py
+++ b/data_management/management/commands/_example_data.py
@@ -1,0 +1,289 @@
+from dateutil import parser
+
+from data_management.models import (
+    Author,
+    CodeRepoRelease,
+    CodeRun,
+    DataProduct,
+    ExternalObject,
+    FileType,
+    Object,
+    StorageLocation,
+    StorageRoot,
+    Namespace,
+)
+from django.contrib.auth import get_user_model
+
+
+def init_db():
+    user = get_user_model().objects.get_or_create(username="exampleusera")[0]
+    get_user_model().objects.get_or_create(username="exampleuserb")
+    get_user_model().objects.get_or_create(username="exampleuserc")
+
+    sr_github = StorageRoot.objects.get_or_create(
+        updated_by=user, root="https://github.com"
+    )[0]
+
+    sr_textfiles = StorageRoot.objects.get_or_create(
+        updated_by=user, root="https://data.scrc.uk/api/text_file/"
+    )[0]
+
+    sr_example = StorageRoot.objects.get_or_create(
+        updated_by=user, root="https://example.org/"
+    )[0]
+
+    sl_file_1 = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="file_strore/1.txt",
+        hash="346df017da291fe0e9d1169846efb12f3377aef1",
+        storage_root=sr_example,
+    )[0]
+
+    sl_file_2 = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="file_strore/2.txt",
+        hash="346df017da291fe0e9d1169846efb12f3377aef2",
+        storage_root=sr_example,
+    )[0]
+
+    sl_code = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="ScottishCovidResponse/SCRCdata repository",
+        hash="b98782baaaea3bf6cc2882ad7d1c5de7aece362a",
+        storage_root=sr_github,
+    )[0]
+
+    sl_model_config = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="15/?format=text",
+        hash="5b6fafc594cdb619104ceeef7a4802f4086e90e8",
+        storage_root=sr_textfiles,
+    )[0]
+
+    sl_script = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="16/?format=text",
+        hash="5b6fafc594cdb619104ceeef7a4802f4086e90e9",
+        storage_root=sr_textfiles,
+    )[0]
+
+    sl_input_1 = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="input/1",
+        hash="5b6fafc594cdb619104ceeef7a4802f4086e90a1",
+        storage_root=sr_textfiles,
+    )[0]
+
+    sl_input_2 = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="input/2",
+        hash="5b6fafc594cdb619104ceeef7a4802f4086e90a2",
+        storage_root=sr_textfiles,
+    )[0]
+
+    sl_input_3 = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="input/3",
+        hash="5b6fafc594cdb619104ceeef7a4802f4086e90a3",
+        storage_root=sr_textfiles,
+    )[0]
+
+    sl_input_4 = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="input/4",
+        hash="5b6fafc594cdb619104ceeef7a4802f4086e90a4",
+        storage_root=sr_textfiles,
+    )[0]
+
+    sl_output_1 = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="output/1",
+        hash="5b6fafc594cdb619104ceeef7a4802f4086e90b1",
+        storage_root=sr_textfiles,
+    )[0]
+
+    sl_output_2 = StorageLocation.objects.get_or_create(
+        updated_by=user,
+        path="output/2",
+        hash="5b6fafc594cdb619104ceeef7a4802f4086e90b2",
+        storage_root=sr_textfiles,
+    )[0]
+
+    text_file = FileType.objects.get_or_create(
+        updated_by=user, extension="txt", name="text file"
+    )[0]
+
+    a1 = Author.objects.get_or_create(updated_by=user, name="Ivana Valenti")[0]
+    a2 = Author.objects.get_or_create(updated_by=user, name="Maria Cipriani")[0]
+    a3 = Author.objects.get_or_create(updated_by=user, name="Rosanna Massabeti")[0]
+
+    o_code = Object.objects.get_or_create(updated_by=user, storage_location=sl_code)[0]
+    o_code_2 = Object.objects.get_or_create(updated_by=user, storage_location=sl_code)[
+        0
+    ]
+    o_model_config = Object.objects.get_or_create(
+        updated_by=user, storage_location=sl_model_config
+    )[0]
+    o_script = Object.objects.get_or_create(
+        updated_by=user, storage_location=sl_script, file_type=text_file
+    )[0]
+
+    o_input_1 = Object.objects.get_or_create(
+        updated_by=user, storage_location=sl_input_1, description="input 1 object"
+    )[0]
+    o_input_1.authors.add(a1)
+    o_input_2 = Object.objects.get_or_create(
+        updated_by=user, storage_location=sl_input_2, description="input 2 object"
+    )[0]
+    o_input_2.authors.add(a2)
+    o_input_3 = Object.objects.get_or_create(
+        updated_by=user, storage_location=sl_input_3, description="input 3 object"
+    )[0]
+    o_input_3.authors.add(a3)
+    o_input_4 = Object.objects.get_or_create(
+        updated_by=user, storage_location=sl_input_4, description="input 4 object"
+    )[0]
+    o_output_1 = Object.objects.get_or_create(
+        updated_by=user, storage_location=sl_output_1, description="output 1 object"
+    )[0]
+    o_output_1.authors.add(a3)
+    o_output_2 = Object.objects.get_or_create(
+        updated_by=user, storage_location=sl_output_2, description="output 2 object"
+    )[0]
+    o_output_2.authors.add(a3)
+    o_output_3 = Object.objects.get_or_create(
+        updated_by=user, description="output 2 object"
+    )[0]
+    o_output_4 = Object.objects.get_or_create(
+        updated_by=user, description="output 2 object"
+    )[0]
+
+    n_prov = Namespace.objects.get_or_create(updated_by=user, name="prov")[0]
+
+    dp_cr_input_1 = DataProduct.objects.get_or_create(
+        updated_by=user,
+        object=o_input_1,
+        namespace=n_prov,
+        name="this/is/cr/example/input/1",
+        version="0.2.0",
+    )[0]
+
+    ExternalObject.objects.get_or_create(
+        updated_by=user,
+        data_product=dp_cr_input_1,
+        alternate_identifier="this_is_cr_example_input_1",
+        alternate_identifier_type="text",
+        release_date=parser.isoparse("2020-07-10T18:38:00Z"),
+        title="this is cr example input 1",
+        description="this is code run example input 1",
+        original_store=sl_file_1,
+    )
+
+    dp_cr_output_1 = DataProduct.objects.get_or_create(
+        updated_by=user,
+        object=o_output_1,
+        namespace=n_prov,
+        name="this/is/cr/example/output/1",
+        version="0.2.0",
+    )[0]
+
+    ExternalObject.objects.get_or_create(
+        updated_by=user,
+        data_product=dp_cr_output_1,
+        identifier="this_is_cr_example_output_1_id",
+        alternate_identifier="this_is_cr_example_output_1",
+        alternate_identifier_type="text",
+        release_date=parser.isoparse("2021-07-10T18:38:00Z"),
+        title="this is cr example output 1",
+        description="this is code run example output 1",
+        original_store=sl_file_2,
+    )
+
+    dp_cr_output_2 = DataProduct.objects.get_or_create(
+        updated_by=user,
+        object=o_output_2,
+        namespace=n_prov,
+        name="this/is/cr/example/output/2",
+        version="0.2.0",
+    )[0]
+
+    ExternalObject.objects.get_or_create(
+        updated_by=user,
+        data_product=dp_cr_output_2,
+        identifier="this_is_cr_example_output_2",
+        release_date=parser.isoparse("2021-07-10T18:38:00Z"),
+        title="this is cr example output 2",
+    )
+
+    DataProduct.objects.get_or_create(
+        updated_by=user,
+        object=o_input_2,
+        namespace=n_prov,
+        name="this/is/cr/example/input/2",
+        version="0.2.0",
+    )
+
+    DataProduct.objects.get_or_create(
+        updated_by=user,
+        object=o_input_3,
+        namespace=n_prov,
+        name="this/is/cr/example/input/3",
+        version="0.2.0",
+    )
+
+    DataProduct.objects.get_or_create(
+        updated_by=user,
+        object=o_output_3,
+        namespace=n_prov,
+        name="this/is/cr/example/output/3",
+        version="0.3.0",
+    )
+
+    DataProduct.objects.get_or_create(
+        updated_by=user,
+        object=o_output_4,
+        namespace=n_prov,
+        name="this/is/cr/example/output/4",
+        version="0.4.0",
+    )
+
+    CodeRepoRelease.objects.get_or_create(
+        updated_by=user,
+        name="ScottishCovidResponse/SCRCdata",
+        version="0.1.0",
+        website="https://github.com/ScottishCovidResponse/SCRCdata",
+        object=o_code,
+    )
+
+    cr1 = CodeRun.objects.get_or_create(
+        updated_by=user,
+        run_date="2021-07-17T18:21:11Z",
+        description="Test run",
+        code_repo=o_code,
+        model_config=o_model_config,
+        submission_script=o_script,
+    )[0]
+    cr1.inputs.set(
+        [
+            o_input_1.components.first(),
+            o_input_2.components.first(),
+            o_input_3.components.first(),
+            o_input_4.components.first(),
+        ]
+    )
+    cr1.outputs.set([o_output_1.components.first(), o_output_2.components.first()])
+
+    cr2 = CodeRun.objects.get_or_create(
+        updated_by=user,
+        run_date="2021-07-17T19:21:11Z",
+        code_repo=o_code_2,
+        submission_script=o_script,
+    )[0]
+    cr2.inputs.set([o_input_1.components.first()])
+    cr2.outputs.set([o_output_3.components.first()])
+
+    cr3 = CodeRun.objects.get_or_create(
+        updated_by=user, run_date="2021-07-17T19:21:11Z", submission_script=o_script
+    )[0]
+    cr3.inputs.set([o_input_1.components.first()])
+    cr3.outputs.set([o_output_4.components.first()])

--- a/data_management/management/commands/_example_data.py
+++ b/data_management/management/commands/_example_data.py
@@ -1,15 +1,14 @@
-from dateutil import parser
-
 from data_management.models import (
     Author,
-    CodeRepoRelease,
     CodeRun,
     DataProduct,
     ExternalObject,
     FileType,
     Object,
+    ObjectComponent,
     StorageLocation,
     StorageRoot,
+    UserAuthor,
     Namespace,
 )
 from django.contrib.auth import get_user_model
@@ -17,273 +16,362 @@ from django.contrib.auth import get_user_model
 
 def init_db():
     user = get_user_model().objects.get_or_create(username="exampleusera")[0]
-    get_user_model().objects.get_or_create(username="exampleuserb")
-    get_user_model().objects.get_or_create(username="exampleuserc")
 
-    sr_github = StorageRoot.objects.get_or_create(
-        updated_by=user, root="https://github.com"
+    csv_file = FileType.objects.get_or_create(
+        updated_by=user, extension="csv", name="Comma-Separated Values File"
     )[0]
-
-    sr_textfiles = StorageRoot.objects.get_or_create(
-        updated_by=user, root="https://data.scrc.uk/api/text_file/"
+    FileType.objects.get_or_create(
+        updated_by=user, extension="toml", name="TOML Configuration File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="json", name="JavaScript Object Notation File"
+    )
+    yaml_document = FileType.objects.get_or_create(
+        updated_by=user, extension="yaml", name="YAML Document"
     )[0]
-
-    sr_example = StorageRoot.objects.get_or_create(
-        updated_by=user, root="https://example.org/"
+    FileType.objects.get_or_create(
+        updated_by=user, extension="ini", name="Windows Initialization File"
+    )
+    FileType.objects.get_or_create(updated_by=user, extension="dat", name="Data File")
+    FileType.objects.get_or_create(
+        updated_by=user, extension="npy", name="Python NumPy Array File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="xls", name="Microsoft Excel Spreadsheet (Legacy)"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="xlsx", name="Microsoft Excel Spreadsheet"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="doc", name="Microsoft Word Document (Legacy)"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="docx", name="Microsoft Word Document"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="txt", name="Plain Text File"
+    )
+    FileType.objects.get_or_create(updated_by=user, extension="r", name="R Script File")
+    FileType.objects.get_or_create(
+        updated_by=user, extension="exe", name="Windows Executable File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="jl", name="Julia Source Code File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="java", name="Java Source Code File"
+    )
+    shell_script = FileType.objects.get_or_create(
+        updated_by=user, extension="sh", name="Bash Shell Script"
     )[0]
-
-    sl_file_1 = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="file_strore/1.txt",
-        hash="346df017da291fe0e9d1169846efb12f3377aef1",
-        storage_root=sr_example,
+    FileType.objects.get_or_create(
+        updated_by=user, extension="ps1", name="Windows PowerShell Cmdlet File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="h5", name="Hierarchical Data Format 5 File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="hdf5", name="Hierarchical Data Format 5 File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="pdb", name="Program Database"
+    )
+    FileType.objects.get_or_create(updated_by=user, extension="zip", name="Zipped File")
+    FileType.objects.get_or_create(
+        updated_by=user, extension="tar", name="Consolidated Unix File Archive"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="tar.gz", name="Compressed Tarball File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="gz", name="Gnu Zipped Archive"
+    )
+    FileType.objects.get_or_create(updated_by=user, extension="xml", name="XML File")
+    FileType.objects.get_or_create(
+        updated_by=user, extension="ascii", name="ASCII Text File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="sql", name="Structured Query Language Data File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="sas", name="SAS Program File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="rdata", name="R Workspace File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="tab", name="Typinator Set File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="cfg", name="Configuration File"
+    )
+    FileType.objects.get_or_create(
+        updated_by=user, extension="pkl", name="Python Pickle File"
+    )
+    python_script = FileType.objects.get_or_create(
+        updated_by=user, extension="py", name="Python Script"
     )[0]
-
-    sl_file_2 = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="file_strore/2.txt",
-        hash="346df017da291fe0e9d1169846efb12f3377aef2",
-        storage_root=sr_example,
-    )[0]
-
-    sl_code = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="ScottishCovidResponse/SCRCdata repository",
-        hash="b98782baaaea3bf6cc2882ad7d1c5de7aece362a",
-        storage_root=sr_github,
-    )[0]
-
-    sl_model_config = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="15/?format=text",
-        hash="5b6fafc594cdb619104ceeef7a4802f4086e90e8",
-        storage_root=sr_textfiles,
-    )[0]
-
-    sl_script = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="16/?format=text",
-        hash="5b6fafc594cdb619104ceeef7a4802f4086e90e9",
-        storage_root=sr_textfiles,
-    )[0]
-
-    sl_input_1 = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="input/1",
-        hash="5b6fafc594cdb619104ceeef7a4802f4086e90a1",
-        storage_root=sr_textfiles,
-    )[0]
-
-    sl_input_2 = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="input/2",
-        hash="5b6fafc594cdb619104ceeef7a4802f4086e90a2",
-        storage_root=sr_textfiles,
-    )[0]
-
-    sl_input_3 = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="input/3",
-        hash="5b6fafc594cdb619104ceeef7a4802f4086e90a3",
-        storage_root=sr_textfiles,
-    )[0]
-
-    sl_input_4 = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="input/4",
-        hash="5b6fafc594cdb619104ceeef7a4802f4086e90a4",
-        storage_root=sr_textfiles,
-    )[0]
-
-    sl_output_1 = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="output/1",
-        hash="5b6fafc594cdb619104ceeef7a4802f4086e90b1",
-        storage_root=sr_textfiles,
-    )[0]
-
-    sl_output_2 = StorageLocation.objects.get_or_create(
-        updated_by=user,
-        path="output/2",
-        hash="5b6fafc594cdb619104ceeef7a4802f4086e90b2",
-        storage_root=sr_textfiles,
-    )[0]
-
-    text_file = FileType.objects.get_or_create(
-        updated_by=user, extension="txt", name="text file"
-    )[0]
-
-    a1 = Author.objects.get_or_create(updated_by=user, name="Ivana Valenti")[0]
-    a2 = Author.objects.get_or_create(updated_by=user, name="Maria Cipriani")[0]
-    a3 = Author.objects.get_or_create(updated_by=user, name="Rosanna Massabeti")[0]
-
-    o_code = Object.objects.get_or_create(updated_by=user, storage_location=sl_code)[0]
-    o_code_2 = Object.objects.get_or_create(updated_by=user, storage_location=sl_code)[
+    pdf = FileType.objects.get_or_create(updated_by=user, extension="pdf", name="pdf")[
         0
     ]
-    o_model_config = Object.objects.get_or_create(
-        updated_by=user, storage_location=sl_model_config
-    )[0]
-    o_script = Object.objects.get_or_create(
-        updated_by=user, storage_location=sl_script, file_type=text_file
-    )[0]
 
-    o_input_1 = Object.objects.get_or_create(
-        updated_by=user, storage_location=sl_input_1, description="input 1 object"
-    )[0]
-    o_input_1.authors.add(a1)
-    o_input_2 = Object.objects.get_or_create(
-        updated_by=user, storage_location=sl_input_2, description="input 2 object"
-    )[0]
-    o_input_2.authors.add(a2)
-    o_input_3 = Object.objects.get_or_create(
-        updated_by=user, storage_location=sl_input_3, description="input 3 object"
-    )[0]
-    o_input_3.authors.add(a3)
-    o_input_4 = Object.objects.get_or_create(
-        updated_by=user, storage_location=sl_input_4, description="input 4 object"
-    )[0]
-    o_output_1 = Object.objects.get_or_create(
-        updated_by=user, storage_location=sl_output_1, description="output 1 object"
-    )[0]
-    o_output_1.authors.add(a3)
-    o_output_2 = Object.objects.get_or_create(
-        updated_by=user, storage_location=sl_output_2, description="output 2 object"
-    )[0]
-    o_output_2.authors.add(a3)
-    o_output_3 = Object.objects.get_or_create(
-        updated_by=user, description="output 2 object"
-    )[0]
-    o_output_4 = Object.objects.get_or_create(
-        updated_by=user, description="output 2 object"
-    )[0]
-
-    n_prov = Namespace.objects.get_or_create(updated_by=user, name="prov")[0]
-
-    dp_cr_input_1 = DataProduct.objects.get_or_create(
+    author = Author.objects.get_or_create(
         updated_by=user,
-        object=o_input_1,
-        namespace=n_prov,
-        name="this/is/cr/example/input/1",
-        version="0.2.0",
+        name="Interface Test",
+        uuid="2ddb2358-84bf-43ff-b2aa-3ac7dc3b49f1",
     )[0]
+
+    UserAuthor.objects.get_or_create(updated_by=user, user=user, author=author)
+
+    storage_root_1 = StorageRoot.objects.get_or_create(
+        id=1,
+        root="file:///var/folders/0f/fj5r_1ws15x4jzgnm27h_y6h0000gr/T/tmptjtzaz9p/data_store/",
+        local=True,
+        updated_by=user,
+    )[0]
+
+    storage_root_2 = StorageRoot.objects.get_or_create(
+        id=2,
+        root="/var/folders/0f/fj5r_1ws15x4jzgnm27h_y6h0000gr/T/tmptjtzaz9p/data_store",
+        local=True,
+        updated_by=user,
+    )[0]
+
+    storage_location_1 = StorageLocation.objects.get_or_create(
+        path="BioSS/disease/sars_cov2/SEINRD_model/parameters/static_params/0.20210914.0.csv",
+        hash="ff77a4ec301a7f7520784e5a6ba0e9539b80867d",
+        public=True,
+        updated_by=user,
+        storage_root=storage_root_1,
+    )[0]
+
+    storage_location_2 = StorageLocation.objects.get_or_create(
+        path="BioSS/disease/sars_cov2/SEINRD_model/parameters/rts/0.20210914.0.csv",
+        hash="51d991044075b64994f4c795b07d85c9fd351f1a",
+        public=True,
+        updated_by=user,
+        storage_root=storage_root_1,
+    )[0]
+
+    storage_location_3 = StorageLocation.objects.get_or_create(
+        path="BioSS/disease/sars_cov2/SEINRD_model/parameters/efoi/0.20210914.0.csv",
+        hash="3b6825cb72915d2dfbb74439f78cccfb92129368",
+        public=True,
+        updated_by=user,
+        storage_root=storage_root_1,
+    )[0]
+
+    storage_location_4 = StorageLocation.objects.get_or_create(
+        path="/var/folders/0f/fj5r_1ws15x4jzgnm27h_y6h0000gr/T/tmptjtzaz9p/data_store/jobs/2021-09-14_16_05_18_613674/config.yaml",
+        hash="570605496a6ae60062c476330d49fe21c2736fca",
+        public=True,
+        updated_by=user,
+        storage_root=storage_root_2,
+    )[0]
+
+    storage_location_5 = StorageLocation.objects.get_or_create(
+        path="/var/folders/0f/fj5r_1ws15x4jzgnm27h_y6h0000gr/T/tmptjtzaz9p/data_store/jobs/2021-09-14_16_05_18_613674/script.sh",
+        hash="62f1262d526266d374161c29ee4a9763f5b0ce45",
+        public=True,
+        updated_by=user,
+        storage_root=storage_root_2,
+    )[0]
+
+    storage_location_6 = StorageLocation.objects.get_or_create(
+        path="testing/disease/sars_cov2/SEINRD_model/results/model_output/73ebe2360650ffb3f885d607e04ac2fa036bf8c6.csv",
+        hash="73ebe2360650ffb3f885d607e04ac2fa036bf8c6",
+        public=True,
+        updated_by=user,
+        storage_root=storage_root_2,
+    )[0]
+
+    storage_location_7 = StorageLocation.objects.get_or_create(
+        path="testing/disease/sars_cov2/SEINRD_model/results/figure/6309da2221b0917fcbfa8c02098e499c63e01753.pdf",
+        hash="6309da2221b0917fcbfa8c02098e499c63e01753",
+        public=True,
+        updated_by=user,
+        storage_root=storage_root_2,
+    )[0]
+
+    object_1 = Object.objects.get_or_create(
+        uuid="a5f0522f-6c7b-4d5b-a328-2c129b23652a",
+        description="Static parameters of the model",
+        updated_by=user,
+        storage_location=storage_location_1,
+        file_type=python_script,
+    )[0]
+    object_1.authors.add(author)
+
+    object_2 = Object.objects.get_or_create(
+        uuid="f372a204-5b1c-4b31-a39d-4473d607f12a",
+        description="Values of Rt at time t",
+        updated_by=user,
+        storage_location=storage_location_2,
+        file_type=python_script,
+    )[0]
+    object_2.authors.add(author)
+
+    object_3 = Object.objects.get_or_create(
+        uuid="00f26144-2ee2-46f8-b4fe-fa2d8bfed341",
+        description="Effective force of infection at time t",
+        updated_by=user,
+        storage_location=storage_location_3,
+        file_type=python_script,
+    )[0]
+    object_3.authors.add(author)
+
+    object_4 = Object.objects.get_or_create(
+        uuid="ff351c5b-0d53-4341-92b3-4a54a09190e1",
+        description="Working config.yaml file location in local datastore",
+        updated_by=user,
+        storage_location=storage_location_4,
+        file_type=yaml_document,
+    )[0]
+    object_4.authors.add(author)
+
+    object_5 = Object.objects.get_or_create(
+        uuid="d243ebc0-d6aa-4c09-90ea-331c87e24973",
+        description="Submission script location in local datastore",
+        updated_by=user,
+        storage_location=storage_location_5,
+        file_type=shell_script,
+    )[0]
+    object_5.authors.add(author)
+
+    object_6 = Object.objects.get_or_create(
+        uuid="fc1ff6fc-d42a-4103-9991-9f2a0d50a761",
+        updated_by=user,
+        storage_location=storage_location_6,
+        file_type=csv_file,
+    )[0]
+    object_6.authors.add(author)
+
+    object_7 = Object.objects.get_or_create(
+        uuid="36696f81-cdf1-4871-a984-476132b2b4b9",
+        updated_by=user,
+        storage_location=storage_location_7,
+        file_type=pdf,
+    )[0]
+    object_7.authors.add(author)
+
+    code_run = CodeRun.objects.get_or_create(
+        uuid="bff4b8f6-f720-4a73-b63d-1f73229663db",
+        run_date="2021-09-14T16:05:22Z",
+        description="Simple Model",
+        updated_by=user,
+        model_config=object_4,
+        submission_script=object_5,
+    )[0]
+
+    object_component_1 = ObjectComponent.objects.get_or_create(
+        name="whole_object", whole_object=True, updated_by=user, object=object_1
+    )[0]
+    object_component_1.inputs_of.add(code_run)
+
+    object_component_2 = ObjectComponent.objects.get_or_create(
+        name="whole_object", whole_object=True, updated_by=user, object=object_2
+    )[0]
+    object_component_2.inputs_of.add(code_run)
+
+    object_component_3 = ObjectComponent.objects.get_or_create(
+        name="whole_object", whole_object=True, updated_by=user, object=object_3
+    )[0]
+    object_component_3.inputs_of.add(code_run)
+
+    ObjectComponent.objects.get_or_create(
+        name="whole_object", whole_object=True, updated_by=user, object=object_4
+    )
+
+    ObjectComponent.objects.get_or_create(
+        name="whole_object", whole_object=True, updated_by=user, object=object_5
+    )
+
+    object_component_6 = ObjectComponent.objects.get_or_create(
+        name="whole_object", whole_object=True, updated_by=user, object=object_6
+    )[0]
+    object_component_6.outputs_of.add(code_run)
+
+    object_component_7 = ObjectComponent.objects.get_or_create(
+        name="whole_object", whole_object=True, updated_by=user, object=object_7
+    )[0]
+    object_component_7.outputs_of.add(code_run)
+
+    namespace = Namespace.objects.get_or_create(
+        name="BioSS",
+        full_name="Biomathematics and Statistics Scotland",
+        website="https://www.bioss.ac.uk",
+        updated_by=user,
+    )[0]
+
+    data_product_1 = DataProduct.objects.get_or_create(
+        name="disease/sars_cov2/SEINRD_model/parameters/static_params",
+        version="0.20210914.0",
+        updated_by=user,
+        object=object_1,
+        namespace=namespace,
+    )[0]
+
+    data_product_2 = DataProduct.objects.get_or_create(
+        name="disease/sars_cov2/SEINRD_model/parameters/rts",
+        version="0.20210914.0",
+        updated_by=user,
+        object=object_2,
+        namespace=namespace,
+    )[0]
+
+    data_product_3 = DataProduct.objects.get_or_create(
+        name="disease/sars_cov2/SEINRD_model/parameters/efoi",
+        version="0.20210914.0",
+        updated_by=user,
+        object=object_3,
+        namespace=namespace,
+    )[0]
+
+    DataProduct.objects.get_or_create(
+        name="disease/sars_cov2/SEINRD_model/results/model_output",
+        version="0.0.1",
+        updated_by=user,
+        object=object_6,
+        namespace=namespace,
+    )
+
+    DataProduct.objects.get_or_create(
+        name="disease/sars_cov2/SEINRD_model/results/figure",
+        version="0.0.1",
+        updated_by=user,
+        object=object_7,
+        namespace=namespace,
+    )
 
     ExternalObject.objects.get_or_create(
+        alternate_identifier="Simple model parameters - Static parameters of the model",
+        alternate_identifier_type="simple_model_params",
+        primary_not_supplement=True,
+        release_date="2021-09-14T16:04:49Z",
+        title="Static parameters of the model",
+        version="0.20210914.0",
         updated_by=user,
-        data_product=dp_cr_input_1,
-        alternate_identifier="this_is_cr_example_input_1",
-        alternate_identifier_type="text",
-        release_date=parser.isoparse("2020-07-10T18:38:00Z"),
-        title="this is cr example input 1",
-        description="this is code run example input 1",
-        original_store=sl_file_1,
+        data_product=data_product_1,
     )
-
-    dp_cr_output_1 = DataProduct.objects.get_or_create(
-        updated_by=user,
-        object=o_output_1,
-        namespace=n_prov,
-        name="this/is/cr/example/output/1",
-        version="0.2.0",
-    )[0]
 
     ExternalObject.objects.get_or_create(
+        alternate_identifier="Simple model parameters - Values of Rt at time t",
+        alternate_identifier_type="simple_model_params",
+        primary_not_supplement=True,
+        release_date="2021-09-14T16:04:49Z",
+        title="Values of Rt at time t",
+        version="0.20210914.0",
         updated_by=user,
-        data_product=dp_cr_output_1,
-        identifier="this_is_cr_example_output_1_id",
-        alternate_identifier="this_is_cr_example_output_1",
-        alternate_identifier_type="text",
-        release_date=parser.isoparse("2021-07-10T18:38:00Z"),
-        title="this is cr example output 1",
-        description="this is code run example output 1",
-        original_store=sl_file_2,
+        data_product=data_product_2,
     )
-
-    dp_cr_output_2 = DataProduct.objects.get_or_create(
-        updated_by=user,
-        object=o_output_2,
-        namespace=n_prov,
-        name="this/is/cr/example/output/2",
-        version="0.2.0",
-    )[0]
 
     ExternalObject.objects.get_or_create(
+        alternate_identifier="Simple model parameters - Effective force of infection",
+        alternate_identifier_type="simple_model_params",
+        primary_not_supplement=True,
+        release_date="2021-09-14T16:04:49Z",
+        title="Effective force of infection at time t",
+        version="0.20210914.0",
         updated_by=user,
-        data_product=dp_cr_output_2,
-        identifier="this_is_cr_example_output_2",
-        release_date=parser.isoparse("2021-07-10T18:38:00Z"),
-        title="this is cr example output 2",
+        data_product=data_product_3,
     )
-
-    DataProduct.objects.get_or_create(
-        updated_by=user,
-        object=o_input_2,
-        namespace=n_prov,
-        name="this/is/cr/example/input/2",
-        version="0.2.0",
-    )
-
-    DataProduct.objects.get_or_create(
-        updated_by=user,
-        object=o_input_3,
-        namespace=n_prov,
-        name="this/is/cr/example/input/3",
-        version="0.2.0",
-    )
-
-    DataProduct.objects.get_or_create(
-        updated_by=user,
-        object=o_output_3,
-        namespace=n_prov,
-        name="this/is/cr/example/output/3",
-        version="0.3.0",
-    )
-
-    DataProduct.objects.get_or_create(
-        updated_by=user,
-        object=o_output_4,
-        namespace=n_prov,
-        name="this/is/cr/example/output/4",
-        version="0.4.0",
-    )
-
-    CodeRepoRelease.objects.get_or_create(
-        updated_by=user,
-        name="ScottishCovidResponse/SCRCdata",
-        version="0.1.0",
-        website="https://github.com/ScottishCovidResponse/SCRCdata",
-        object=o_code,
-    )
-
-    cr1 = CodeRun.objects.get_or_create(
-        updated_by=user,
-        run_date="2021-07-17T18:21:11Z",
-        description="Test run",
-        code_repo=o_code,
-        model_config=o_model_config,
-        submission_script=o_script,
-    )[0]
-    cr1.inputs.set(
-        [
-            o_input_1.components.first(),
-            o_input_2.components.first(),
-            o_input_3.components.first(),
-            o_input_4.components.first(),
-        ]
-    )
-    cr1.outputs.set([o_output_1.components.first(), o_output_2.components.first()])
-
-    cr2 = CodeRun.objects.get_or_create(
-        updated_by=user,
-        run_date="2021-07-17T19:21:11Z",
-        code_repo=o_code_2,
-        submission_script=o_script,
-    )[0]
-    cr2.inputs.set([o_input_1.components.first()])
-    cr2.outputs.set([o_output_3.components.first()])
-
-    cr3 = CodeRun.objects.get_or_create(
-        updated_by=user, run_date="2021-07-17T19:21:11Z", submission_script=o_script
-    )[0]
-    cr3.inputs.set([o_input_1.components.first()])
-    cr3.outputs.set([o_output_4.components.first()])

--- a/data_management/management/commands/add_example_data.py
+++ b/data_management/management/commands/add_example_data.py
@@ -1,0 +1,54 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand
+from django.db.utils import OperationalError
+
+from data_management.management.commands._example_data import init_db
+from data_management.models import Object
+
+
+class Command(BaseCommand):
+
+    help = "Add example data to the registry"
+
+    def add_arguments(self, parser):
+        """
+        Define the options.
+
+        """
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Add the example data even if the database is not empty",
+        )
+
+    def handle(self, **options):
+
+        force = options["force"]
+
+        try:
+            user = get_user_model().objects.all()
+            group = Group.objects.all()
+            objects = Object.objects.all()
+
+            if (len(user) > 0 or len(group) > 0 or len(objects) > 0) and not force:
+                self.stderr.write(
+                    "This command will only run if the database is empty. "
+                    "Use the '--force' option to override this behaviour."
+                )
+                return
+
+        except OperationalError as ex:
+            self.stderr.write(f"ERROR: {ex}")
+            self.stderr.write(
+                "It looks like the database may not have been initialised"
+            )
+            self.stderr.write("You could try:")
+            self.stderr.write("python manage.py makemigrations custom_user")
+            self.stderr.write("python manage.py makemigrations data_management")
+            self.stderr.write("python manage.py migrate")
+            return
+
+        init_db()
+
+        self.stdout.write("The example data has been added to the database")

--- a/data_management/management/commands/add_example_data.py
+++ b/data_management/management/commands/add_example_data.py
@@ -1,5 +1,3 @@
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
 from django.db.utils import OperationalError
 
@@ -27,13 +25,11 @@ class Command(BaseCommand):
         force = options["force"]
 
         try:
-            user = get_user_model().objects.all()
-            group = Group.objects.all()
             objects = Object.objects.all()
 
-            if (len(user) > 0 or len(group) > 0 or len(objects) > 0) and not force:
+            if len(objects) > 0 and not force:
                 self.stderr.write(
-                    "This command will only run if the database is empty. "
+                    "This command will only run if the database contains no 'Objects'. "
                     "Use the '--force' option to override this behaviour."
                 )
                 return


### PR DESCRIPTION
This code provides a `manage.py` option to allow the user to generate some example data for the registry database.

If the registry is running in a virtual environment then ensure that this environment is activated. Also ensure the `DJANGO_SETTINGS_MODULE` environment variable is set. You can then run the command `python manage.py add_example_data`

```
. venv/bin/activate
export DJANGO_SETTINGS_MODULE=drams.vagrant
python manage.py add_example_data
```

By default the script will only run is the registry database is empty. If you wish to add the data to a database that is not empty then use the `--force` option.

```
python manage.py add_example_data --force
```