### PR TITLE
Allow users to set the dpi of a prov report

### DIFF
--- a/data_management/prov.py
+++ b/data_management/prov.py
@@ -334,14 +334,17 @@ def generate_prov_document(data_product, request):
     return doc
 
 
-def serialize_prov_document(doc, format_, aspect_ratio, show_attributes=True):
+def serialize_prov_document(
+    doc, format_, aspect_ratio, dpi=None, show_attributes=True
+):
     """
     Serialise a PROV document as either a JPEG or SVG image or an XML or PROV-N report.
 
     :param doc: A PROV-O document
     :param format_: The format to generate: jpg, svg, xml or provn
     :param aspect_ratio: a float used to define the ratio for images
-    :param show_attributes: a boolean
+    :param dpi:  a float used to define the dpi for images
+    :param show_attributes: a boolean, shows attributes of elements when True
 
     :return: The PROV report in the specified format
 
@@ -349,6 +352,7 @@ def serialize_prov_document(doc, format_, aspect_ratio, show_attributes=True):
     if format_ in ('jpg', 'svg'):
         dot = prov.dot.prov_to_dot(doc, show_element_attributes=show_attributes)
         dot.set_ratio(aspect_ratio)
+        dot.set_dpi(dpi)
         with io.BytesIO() as buf:
             if format_ == 'jpg':
                 buf.write(dot.create_jpg())

--- a/data_management/rest/views.py
+++ b/data_management/rest/views.py
@@ -101,6 +101,11 @@ class ProvReportView(views.APIView):
     renderers. In addition if GraphViz is installed then JPEG and SVG renderers are also
     available.
 
+    This method makes use of the following optional query parameters:
+        aspect_ratio: a float used to define the ratio for images
+        dpi:  a float used to define the dpi for images
+        show_attributes: a boolean, shows attributes of elements when True
+
     """
     try:
         Dot(prog='dot').create()
@@ -127,10 +132,17 @@ class ProvReportView(views.APIView):
         except ValueError:
             aspect_ratio = default_aspect_ratio
 
+        dpi = request.query_params.get('dpi', None)
+        try:
+            dpi = float(dpi)
+        except (TypeError, ValueError):
+            dpi = None
+
         value = serialize_prov_document(
             doc,
             request.accepted_renderer.format,
             aspect_ratio,
+            dpi,
             show_attributes=bool(show_attributes)
         )
         return Response(value)


### PR DESCRIPTION
Add a new optional parameter `dpi` to the `ProvReportView`
This is used to set the dpi of the svg and jpg images produced
for the prov report. The value of `dpi` should be a float.