### PR TITLE
Enable download links for local registry

### DIFF
--- a/data_management/models.py
+++ b/data_management/models.py
@@ -486,6 +486,8 @@ class StorageLocation(BaseModel):
         ]
 
     def full_uri(self):
+        if (self.storage_root.root.startswith('/') or self.storage_root.root.startswith('file://')) and not self.storage_root.root.endswith('/'):
+            return self.storage_root.root + '/' + self.path
         return self.storage_root.root + self.path
 
     def __str__(self):

--- a/data_management/tests/initdb.py
+++ b/data_management/tests/initdb.py
@@ -1,4 +1,5 @@
 from dateutil import parser
+import os
 
 from data_management.models import *
 from django.contrib.auth import get_user_model
@@ -10,6 +11,8 @@ def reset_db():
     Issue.objects.all().delete()
     Source.objects.all().delete()
     Namespace.objects.all().delete()
+
+    os.remove('/tmp/test1.txt')
 
 
 def init_db(test=True):
@@ -58,6 +61,11 @@ def init_db(test=True):
     scl_repo = StorageRoot.objects.create(
         updated_by=user,
         root='https://raw.githubusercontent.com/ScottishCovidResponse/modelling-software-checklist',
+    )
+
+    sr_local = StorageRoot.objects.create(
+        updated_by=user,
+        root='file:///tmp',
     )
 
     sl_repo_prob = StorageLocation.objects.create(
@@ -114,6 +122,16 @@ def init_db(test=True):
         path='main/software-checklist.md',
         hash='f250b8dff4783cb59ee537d375a9420e3fbe66c2',
         storage_root=scl_repo,
+    )
+
+    with open('/tmp/test1.txt', 'w') as fh:
+        fh.write('This is a text file.')
+
+    sl_local_txt = StorageLocation.objects.create(
+        updated_by=user,
+        path='test1.txt',
+        hash='3aab8c814c8da05be7e957c9aefe42b87841f0c0',
+        storage_root=sr_local,
     )
 
     StorageLocation.objects.create(
@@ -217,6 +235,8 @@ def init_db(test=True):
     o_temp_comp = Object.objects.create(updated_by=user, storage_location=sl_temp_comp)
     o_temp_mixing = Object.objects.create(updated_by=user, storage_location=sl_temp_mixing)
     o_temp_pop = Object.objects.create(updated_by=user, storage_location=sl_temp_pop)
+
+    o_local_txt = Object.objects.create(updated_by=user, storage_location=sl_local_txt)
 
     o_code = Object.objects.create(updated_by=user, storage_location=sl_code)
     o_script = Object.objects.create(updated_by=user, storage_location=sl_script)
@@ -415,6 +435,14 @@ def init_db(test=True):
         namespace=n_simp,
         name='human/population',
         version='0.1.0',
+    )
+
+    DataProduct.objects.create(
+        updated_by=user,
+        object=o_local_txt,
+        namespace=n_fair,
+        name='test/txt',
+        version='0.0.1',
     )
 
     crr_code = CodeRepoRelease.objects.create(

--- a/data_management/tests/initdb.py
+++ b/data_management/tests/initdb.py
@@ -124,12 +124,13 @@ def init_db(test=True):
         storage_root=scl_repo,
     )
 
-    with open(os.path.join(os.environ['HOME'], 'test1.txt'), 'w') as fh:
+    local_txt_filename = 'test1.txt'
+    with open(os.path.join(os.environ['HOME'], local_txt_filename), 'w') as fh:
         fh.write('This is a text file.')
 
     sl_local_txt = StorageLocation.objects.create(
         updated_by=user,
-        path='test1.txt',
+        path=local_txt_filename,
         hash='3aab8c814c8da05be7e957c9aefe42b87841f0c0',
         storage_root=sr_local,
     )

--- a/data_management/tests/initdb.py
+++ b/data_management/tests/initdb.py
@@ -12,7 +12,7 @@ def reset_db():
     Source.objects.all().delete()
     Namespace.objects.all().delete()
 
-    os.remove('/tmp/test1.txt')
+    os.remove(os.path.join(os.environ['HOME'], 'test1.txt'))
 
 
 def init_db(test=True):
@@ -65,7 +65,7 @@ def init_db(test=True):
 
     sr_local = StorageRoot.objects.create(
         updated_by=user,
-        root='file:///tmp',
+        root='file://%s' % os.environ['HOME'],
     )
 
     sl_repo_prob = StorageLocation.objects.create(
@@ -124,7 +124,7 @@ def init_db(test=True):
         storage_root=scl_repo,
     )
 
-    with open('/tmp/test1.txt', 'w') as fh:
+    with open(os.path.join(os.environ['HOME'], 'test1.txt'), 'w') as fh:
         fh.write('This is a text file.')
 
     sl_local_txt = StorageLocation.objects.create(

--- a/data_management/tests/test_api.py
+++ b/data_management/tests/test_api.py
@@ -104,7 +104,7 @@ class StorageRootAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         results = response.json()['results']
-        self.assertEqual(len(results), 8)
+        self.assertEqual(len(results), 9)
 
     def test_get_detail(self):
         client = APIClient()
@@ -143,7 +143,7 @@ class StorageLocationAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         results = response.json()['results']
-        self.assertEqual(len(results), 19)
+        self.assertEqual(len(results), 20)
 
     def test_get_detail(self):
         client = APIClient()
@@ -202,6 +202,15 @@ class StorageAPITests(TestCase):
 
         self.assertEqual(response.status_code, 302)
 
+    def test_get_data_product(self):
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        url = reverse("get_data_product", kwargs={"data_product_name": "test/txt", "namespace": "FAIR", "version": "0.0.1"})
+        response = client.get(url)
+
+        self.assertEqual(b''.join(response.streaming_content), bytes("This is a text file.", "utf-8"))
+
+
 class ObjectAPITests(TestCase):
 
     def setUp(self):
@@ -217,7 +226,7 @@ class ObjectAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         results = response.json()['results']
-        self.assertEqual(len(results), 19)
+        self.assertEqual(len(results), 20)
 
     def test_get_detail(self):
         client = APIClient()
@@ -257,7 +266,7 @@ class ObjectComponentAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         results = response.json()['results']
-        self.assertEqual(len(results), 51)
+        self.assertEqual(len(results), 52)
 
     def test_get_detail_whole_object(self):
         client = APIClient()
@@ -272,7 +281,7 @@ class ObjectComponentAPITests(TestCase):
     def test_get_detail(self):
         client = APIClient()
         client.force_authenticate(user=self.user)
-        url = reverse('objectcomponent-detail', kwargs={'pk': 17})
+        url = reverse('objectcomponent-detail', kwargs={'pk': 18})
         response = client.get(url, format='json')
 
         self.assertEqual(response.status_code, 200)
@@ -459,8 +468,8 @@ class QualityControlledAPITests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
-        self.assertEqual(response.json()['object'], 'http://localhost/api/object/15/')
-        self.assertEqual(response.json()['document'], 'http://localhost/api/object/17/')
+        self.assertEqual(response.json()['object'], 'http://localhost/api/object/16/')
+        self.assertEqual(response.json()['document'], 'http://localhost/api/object/18/')
 
 
 class KeywordAPITests(TestCase):
@@ -671,7 +680,7 @@ class DataProductAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         results = response.json()['results']
-        self.assertEqual(len(results), 13)
+        self.assertEqual(len(results), 14)
 
     def test_get_detail(self):
         client = APIClient()
@@ -692,7 +701,7 @@ class DataProductAPITests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/json')
         results = response.json()['results']
-        self.assertEqual(len(results), 9)
+        self.assertEqual(len(results), 10)
 
     def test_filter_by_name(self):
         client = APIClient()

--- a/data_management/tests/test_views.py
+++ b/data_management/tests/test_views.py
@@ -23,7 +23,7 @@ class IndexViewTests(TestCase):
     def test_index_page_displays_data_products(self):
         response = self.client.get(reverse('index'))
         context = response.context[-1]
-        self.assertEqual(len(context['data_products']), 13)
+        self.assertEqual(len(context['data_products']), 14)
 
     def test_index_page_displays_external_objects(self):
         response = self.client.get(reverse('index'))


### PR DESCRIPTION
Currently this supports StorageRoots with or without `file://` as the protocol.

This download feature is disabled for remote registries.

Closes #149.