### PR TITLE
Add feature to export DataProduct table.

### DIFF
--- a/data_management/resources.py
+++ b/data_management/resources.py
@@ -1,0 +1,6 @@
+from import_export import resources
+from .models import DataProduct
+
+class DataProductResource(resources.ModelResource):
+    class Meta:
+        model = DataProduct

--- a/drams/local-settings.py
+++ b/drams/local-settings.py
@@ -1,5 +1,9 @@
 from .base_settings import *
 
+INSTALLED_APPS += ['import_export', ]
+
 MIDDLEWARE += ['whitenoise.middleware.WhiteNoiseMiddleware', ]
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
+
+IMPORT_EXPORT_USE_TRANSACTIONS = True


### PR DESCRIPTION
I was just playing around with the `django-import-export` package, to see how easy it would be to do this. If anyone wants to try it out, `checkout` this branch and run `python manage.py shell`

Then:
```
>>> from data_management.resources import DataProductResource
>>> dataset = DataProductResource().export()
>>> print(dataset.csv)
id,updated_by,last_updated,object,namespace,name,version
1,2,2021-10-20 10:38:22,1,1,disease/sars_cov2/SEINRD_model/parameters/static_params,0.20210914.0
2,2,2021-10-20 10:38:22,2,1,disease/sars_cov2/SEINRD_model/parameters/rts,0.20210914.0
3,2,2021-10-20 10:38:22,3,1,disease/sars_cov2/SEINRD_model/parameters/efoi,0.20210914.0
4,2,2021-10-20 10:38:22,6,1,disease/sars_cov2/SEINRD_model/results/model_output,0.0.1
5,2,2021-10-20 10:38:22,7,1,disease/sars_cov2/SEINRD_model/results/figure,0.0.1
```

You can do things like this! Obviously other formats are available, JSON, YAML, etc...