### PR TITLE
Add environment variable to allowed hosts

### DIFF
--- a/drams/local-settings.py
+++ b/drams/local-settings.py
@@ -4,8 +4,6 @@ import os
 MIDDLEWARE += ['whitenoise.middleware.WhiteNoiseMiddleware', ]
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
-
-ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 ALLOWED_HOSTS.extend(
     filter(None, os.environ.get("FAIR_ALLOWED_HOSTS", "").split(","))
 )

--- a/drams/local-settings.py
+++ b/drams/local-settings.py
@@ -1,5 +1,11 @@
 from .base_settings import *
+import os
 
 MIDDLEWARE += ['whitenoise.middleware.WhiteNoiseMiddleware', ]
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
+
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
+ALLOWED_HOSTS.extend(
+    filter(None, os.environ.get("FAIR_ALLOWED_HOSTS", "").split(","))
+)


### PR DESCRIPTION
Adds an environment variable to set the allowed hosts so that the server can be bound to other IP / Addresses.

I have used FAIR_ALLOWED_HOSTS as the environment variable name.

This was discussed in [#256](https://github.com/FAIRDataPipeline/FAIR-CLI/pull/256)