### PR TITLE
use ro terms vocab for sha1

### DIFF
--- a/data_management/rocrate.py
+++ b/data_management/rocrate.py
@@ -59,7 +59,7 @@ from . import models
 
 RO_TYPE = "@type"
 FILE = "file:"
-SHA1 = {"sha1": "http://xmlns.com/foaf/0.1/#term_sha1"}  # NOSONAR
+SHA1 = {"sha1": "https://w3id.org/ro/terms/workflow-run#sha1"}
 CLI_URL = "https://github.com/FAIRDataPipeline/FAIR-CLI"
 
 


### PR DESCRIPTION
The RO Crate [terms](https://github.com/ResearchObject/ro-terms) now includes the a term for sha1, https://w3id.org/ro/terms/workflow-run#sha1

We now use this in our RO Crates